### PR TITLE
can disable initialize wire

### DIFF
--- a/src/SakuraIO.h
+++ b/src/SakuraIO.h
@@ -106,7 +106,7 @@ protected:
   uint8_t receiveByte();
   uint8_t mode;
 public:
-  SakuraIO_I2C();
+  SakuraIO_I2C(bool initialize_wire = true);
 };
 
 #endif // _SAKURAIO_H_

--- a/src/SakuraIO_I2C.cpp
+++ b/src/SakuraIO_I2C.cpp
@@ -69,7 +69,9 @@ uint8_t SakuraIO_I2C::receiveByte(bool stop){
   return ret;
 }
 
-SakuraIO_I2C::SakuraIO_I2C(){
-  Wire.begin();
+SakuraIO_I2C::SakuraIO_I2C(bool initialize_wire = true) {
+  if (initialize_wire) {
+    Wire.begin();
+  }
   mode = MODE_IDLE;
 }


### PR DESCRIPTION
It can skip Wire.begin() for the Wire object was already initialized outside.